### PR TITLE
Fix non-chain achievements

### DIFF
--- a/src/world_of_warcraft/types/achievements.rs
+++ b/src/world_of_warcraft/types/achievements.rs
@@ -48,7 +48,7 @@ pub struct Achievement {
     pub points: u32,
     pub is_account_wide: bool,
     pub criteria: AchivementCriteria,
-    pub next_achievement: AchivementNextAchievement,
+    pub next_achievement: Option<AchivementNextAchievement>,
     pub media: AchivementMedia,
     pub display_order: u32
 }


### PR DESCRIPTION
Bug fix for non-chain achievements. Non-chain achievements do not have a next_achievement field.