### PR TITLE
Fix namespace for some request types

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -108,7 +108,7 @@ impl BlizzardAPIClient {
         let access_token = locked_token.as_ref().unwrap();
 
         let response_result = self.reqwest_client
-                       .get(format!("{}{}?locale={}", self.get_api_url(), url_path, self.locale))
+                       .get(format!("{}{}?namespace={}&locale={}", self.get_api_url(), url_path, namespace, self.locale))
                        .header("Battlenet-Namespace", format!("{}-{}", namespace, self.region))
                        .bearer_auth(access_token)
                        .send()


### PR DESCRIPTION
For some request types the Blizzard API seems to expect the namespace as part of the query string.

I discovered this while playing with their documentation sample calls.

